### PR TITLE
Signal that redirection headers have been written

### DIFF
--- a/caddyhttp/staticfiles/fileserver.go
+++ b/caddyhttp/staticfiles/fileserver.go
@@ -116,7 +116,7 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 			}
 			urlCopy.Path += "/"
 			http.Redirect(w, r, urlCopy.String(), http.StatusMovedPermanently)
-			return http.StatusMovedPermanently, nil
+			return 0, nil
 		}
 	} else {
 		// ensure no trailing slash
@@ -143,7 +143,7 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 				urlCopy.Path = strings.TrimPrefix(urlCopy.Path, "/")
 			}
 			http.Redirect(w, r, urlCopy.String(), http.StatusMovedPermanently)
-			return http.StatusMovedPermanently, nil
+			return 0, nil
 		}
 	}
 

--- a/caddyhttp/staticfiles/fileserver_test.go
+++ b/caddyhttp/staticfiles/fileserver_test.go
@@ -301,6 +301,9 @@ func TestServeHTTP(t *testing.T) {
 
 		// perform the test
 		status, err := fileServer.ServeHTTP(responseRecorder, request)
+		if status == 0 {
+			status = responseRecorder.Code
+		}
 		etag := responseRecorder.Header().Get("Etag")
 		body := responseRecorder.Body.String()
 		vary := responseRecorder.Header().Get("Vary")


### PR DESCRIPTION
## 1. What does this change do, exactly?
The Handler interface expects a first return value of 0 if headers have already been written. (cf. https://godoc.org/github.com/caddyserver/caddy/caddyhttp/httpserver#Handler)

When using http.Redirect, this is the case as http.Redirect does write headers. When using Caddy with templates, returning http.StatusMovedPermanently could cause a wrong (200) response on a non-slashy request on a directory name. This is probably due to another handler down the chain altering the response, but I didn't debug further.

Returning 0 ensures the redirection will always take place.

## 2. Please link to the relevant issues.
This appears to fix https://github.com/caddyserver/caddy/issues/2114 for me -- I have found the issue only after writing the fix, so based on @mholt's comments there I wonder if I have missed something obvious. If so, I'm sorry and would love to know!

## 3. Which documentation changes (if any) need to be made because of this PR?
None. https://godoc.org/github.com/caddyserver/caddy/caddyhttp/httpserver#Handler is already correct.

## 4. Checklist

- [X] I have written tests and verified that they fail without my change
I added the case that if `status == 0` (following the httpserver.Handler documentation) the status from the responseRecorder should be checked instead
- [X] I have squashed any insignificant commits
- [ ] This change has comments explaining package types, values, functions, and non-obvious lines of code
n/a I think
- [X] I am willing to help maintain this change if there are issues with it later